### PR TITLE
7.4 compatibility

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4837,7 +4837,7 @@ class wsdl extends nusoap_base
                     $wsdlparts = parse_url($this->wsdl);    // this is bogusly simple!
                     foreach ($xs->imports as $ns2 => $list2) {
                         for ($ii = 0; $ii < count($list2); $ii++) {
-                            if (array_key_exists($ii, $list2) AND !$list2[$ii]['loaded']) {
+                            if (array_key_exists($ii, $list2) && !isset($list2[$ii]['loaded'])) {
                                 $this->schemas[$ns][$ns2]->imports[$ns2][$ii]['loaded'] = true;
                                 $url = $list2[$ii]['location'];
                                 if ($url != '') {


### PR DESCRIPTION
The previous notation was still allowing some warnings, and depending on your configuration in E_STRICT throws exceptions.
This will prevent warnings and exceptions when using php 7.4