### PR TITLE
Re-arrange child elements of Fault XML to match SOAP 1.1 XSD

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -1105,8 +1105,8 @@ class nusoap_fault extends nusoap_base
             '<SOAP-ENV:Body>' .
             '<SOAP-ENV:Fault>' .
             $this->serialize_val($this->faultcode, 'faultcode') .
-            $this->serialize_val($this->faultactor, 'faultactor') .
             $this->serialize_val($this->faultstring, 'faultstring') .
+            $this->serialize_val($this->faultactor, 'faultactor') .
             $this->serialize_val($this->faultdetail, 'detail') .
             '</SOAP-ENV:Fault>' .
             '</SOAP-ENV:Body>' .


### PR DESCRIPTION
Although the text specification of SOAP 1.1 only names the children
of the Fault element, the XSD at http://schemas.xmlsoap.org/soap/envelope/
defines them as a "sequence", implying a fixed order (faultcode,
faultstring, faultactor, detail).

Some clients, particularly using .NET, are reported to have issues
parsing the response if the elements don't match that order.

This was reported on Sourceforge as long ago as 2011:
https://sourceforge.net/p/nusoap/discussion/193579/thread/9a5aff36/